### PR TITLE
Update EDDC.toml

### DIFF
--- a/data/EDMM/EDDC.toml
+++ b/data/EDMM/EDDC.toml
@@ -9,7 +9,7 @@ url = "https://chartfox.org/EDDC"
 [[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
-url = "https://1drv.ms/w/c/b6d5387947d75fd6/EWscK06wNcRKoiEevu-0fksBYcVeGRv8-J5j4nRQ0VjoWA?e=nbAnUa"
+url = "https://vats.im/eddcpilotbriefing"
 
 [[airport.links]]
 category = "Scenery"


### PR DESCRIPTION
Changed Pilotbriefig URL to vats.im/icaopilotbriefing to be able to update it without changing the .toml file. :-) LeKl and MoFr are also owners of this Organisation on vats.im (https://vats.im/platform/organizations) Greetings Tobias