### PR TITLE
Update EDDN.toml

### DIFF
--- a/data/EDMM/EDDN.toml
+++ b/data/EDMM/EDDN.toml
@@ -9,7 +9,7 @@ url = "https://chartfox.org/EDDN"
 [[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
-url = "https://1drv.ms/w/c/b6d5387947d75fd6/EV0wOZxFCFpMpnmPzfPpFfcBsdJI8oHmAFhChWtqh6Jzcg?e=poD7c0"
+url = "https://vats.im/eddnpilotbriefing"
 
 [[airport.links]]
 category = "Scenery"


### PR DESCRIPTION
Changed Pilotbriefig URL to vats.im/icaopilotbriefing to be able to update it without changing the .toml file. :-) LeKl and MoFr are also owners of this Organisation on vats.im (https://vats.im/platform/organizations) Greetings Tobias