### PR TITLE
Update EDNY.toml

### DIFF
--- a/data/EDGG/EDNY.toml
+++ b/data/EDGG/EDNY.toml
@@ -9,7 +9,7 @@ url = "https://chartfox.org/EDNY"
 [[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
-url = "https://1drv.ms/b/c/b6d5387947d75fd6/Ebh_JCp74L9FiHPnJtTRTIkB5UZFb6qBNg33vfHzSxUowQ?e=NvbaUO"
+url = "https://vats.im/ednypilotbriefing"
 
 [[airport.links]]
 category = "Scenery"


### PR DESCRIPTION
Changed Pilotbriefig URL to vats.im/icaopilotbriefing to be able to update it without changing the .toml file. :-) LeKl and MoFr are also owners of this Organisation on vats.im (https://vats.im/platform/organizations) Greetings Tobias