### PR TITLE
Update EDDF.toml -> Add Sceneries

### DIFF
--- a/data/EDGG/EDDF.toml
+++ b/data/EDGG/EDDF.toml
@@ -18,10 +18,20 @@ url = "https://knowledgebase.vatsim-germany.org/books/vacdm/page/vacdm-pilot-gui
 
 [[airport.links]]
 category = "Scenery"
-name = "MSFS Scenery by virtualFRA"
+name = "Freeware MSFS Scenery by virtualFRA"
 url = "https://virtual-fra.com/"
 
 [[airport.links]]
 category = "Scenery"
-name = "MSFS Scenery by Aviotek"
+name = "Freeware MSFS Scenery by Aviotek"
 url = "https://orbxdirect.com/product/aviotek-eddf-msfs"
+
+[[airport.links]]
+category = "Scenery"
+name = "Payware MSFS Scenery by Aerosoft"
+url = "https://www.aerosoft.com/de/shop/flight/microsoft-flight-simulator/msfs-szenerien/msfs-europa/4398/aerosoft-mega-airport-frankfurt"
+
+[[airport.links]]
+category = "Scenery"
+name = "Payware X-Plane Scenery by Aerosoft"
+url = "https://www.aerosoft.com/de/shop/flight/x-plane/x-plane-11/szenerien/xp-europa/2226/airport-frankfurt-v2-xp"

--- a/data/EDGG/EDDF.toml
+++ b/data/EDGG/EDDF.toml
@@ -18,20 +18,20 @@ url = "https://knowledgebase.vatsim-germany.org/books/vacdm/page/vacdm-pilot-gui
 
 [[airport.links]]
 category = "Scenery"
-name = "Freeware MSFS Scenery by virtualFRA"
+name = "MSFS Freeware by virtualFRA"
 url = "https://virtual-fra.com/"
 
 [[airport.links]]
 category = "Scenery"
-name = "Freeware MSFS Scenery by Aviotek"
+name = "MSFS Freeware by Aviotek"
 url = "https://orbxdirect.com/product/aviotek-eddf-msfs"
 
 [[airport.links]]
 category = "Scenery"
-name = "Payware MSFS Scenery by Aerosoft"
+name = "MSFS Payware by Aerosoft"
 url = "https://www.aerosoft.com/de/shop/flight/microsoft-flight-simulator/msfs-szenerien/msfs-europa/4398/aerosoft-mega-airport-frankfurt"
 
 [[airport.links]]
 category = "Scenery"
-name = "Payware X-Plane Scenery by Aerosoft"
+name = "X-Plane Payware by Aerosoft"
 url = "https://www.aerosoft.com/de/shop/flight/x-plane/x-plane-11/szenerien/xp-europa/2226/airport-frankfurt-v2-xp"


### PR DESCRIPTION
Add both Aerosoft EDDF Sceneries for MSFS+X-Plane and specify if its freeware or payware. Greetings Tobias

Aviotek EDDF for X-Plane not added because it is unusable for a lot of users. It just uses that much VRAM that there are terrible FPS if you haven't got a 4090.