### PR TITLE
Add VFR Charts EDGG/EDMM

### DIFF
--- a/data/EDGG/EDDF.toml
+++ b/data/EDGG/EDDF.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDF"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDF"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/eddf-frankfurtmain"

--- a/data/EDGG/EDDG.toml
+++ b/data/EDGG/EDDG.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDG"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDG"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/eddg-munsterosnabruck"

--- a/data/EDGG/EDDK.toml
+++ b/data/EDGG/EDDK.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDK"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDK"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/eddk-kolnbonn"

--- a/data/EDGG/EDDL.toml
+++ b/data/EDGG/EDDL.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDL"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDL"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/eddl-dusseldorf"

--- a/data/EDGG/EDDR.toml
+++ b/data/EDGG/EDDR.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDR"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDR"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/eddr-saarbrucken"

--- a/data/EDGG/EDDS.toml
+++ b/data/EDGG/EDDS.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDS"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDS"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/edds-stuttgart"

--- a/data/EDGG/EDFH.toml
+++ b/data/EDGG/EDFH.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDFH"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDFH"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/edfh-frankfurt-hahn"

--- a/data/EDGG/EDFM.toml
+++ b/data/EDGG/EDFM.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDFM"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDFM"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/edfm-mannheim-city"

--- a/data/EDGG/EDGS.toml
+++ b/data/EDGG/EDGS.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDGS"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDGS"
+
+[[airport.links]]
 category = "Scenery"
 name = "MSFS Freeware by uli057"
 url = "https://flightsim.to/file/22730/edgs-airport-siegerland-burbach"

--- a/data/EDGG/EDLN.toml
+++ b/data/EDGG/EDLN.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDLN"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDLN"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/edln-monchengladbach"

--- a/data/EDGG/EDLP.toml
+++ b/data/EDGG/EDLP.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDLP"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDLP"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/edlp-paderbornlippstadt"

--- a/data/EDGG/EDLV.toml
+++ b/data/EDGG/EDLV.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDLV"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDLV"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/edlv-niederrhein"

--- a/data/EDGG/EDLW.toml
+++ b/data/EDGG/EDLW.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDLW"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDLW"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/edlw-dortmund"

--- a/data/EDGG/EDNY.toml
+++ b/data/EDGG/EDNY.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDNY"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDNY"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://vats.im/edny-briefing"

--- a/data/EDGG/EDSB.toml
+++ b/data/EDGG/EDSB.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDSB"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDSB"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg/chapter/edsb-karlsruhebaden-baden"

--- a/data/EDMM/EDDC.toml
+++ b/data/EDMM/EDDC.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDC"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDC"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://vats.im/eddc-briefing"

--- a/data/EDMM/EDDM.toml
+++ b/data/EDMM/EDDM.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDM"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDM"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-munchen-fir-edmm/chapter/eddm-munchen"

--- a/data/EDMM/EDDN.toml
+++ b/data/EDMM/EDDN.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDN"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDN"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://vats.im/eddn-briefing"

--- a/data/EDMM/EDDP.toml
+++ b/data/EDMM/EDDP.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDDP"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDDP"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://vats.im/eddp-briefing"

--- a/data/EDMM/EDJA.toml
+++ b/data/EDMM/EDJA.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDJA"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDJA"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://vats.im/edja-briefing"

--- a/data/EDMM/EDMA.toml
+++ b/data/EDMM/EDMA.toml
@@ -7,6 +7,11 @@ name = "Charts (IFR)"
 url = "https://chartfox.org/EDMA"
 
 [[airport.links]]
+category = "Charts"
+name = "Charts (VFR)"
+url = "https://www.vfraip.de/?EDMA"
+
+[[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://vats.im/edma-briefing"


### PR DESCRIPTION
Add 

[[airport.links]]
category = "Charts"
name = "Charts (VFR)"
url = "https://www.vfraip.de/?ICAO"

to every Airport