### PR TITLE
Changes EDWW FIR

### DIFF
--- a/data/EDWW/EDAH.toml
+++ b/data/EDWW/EDAH.toml
@@ -9,12 +9,7 @@ url = "https://chartfox.org/EDAH"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDAH"
-
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/edah-briefing"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/d6ec7a74cbacb7eb43dec4f69a26c711.html"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDAY.toml
+++ b/data/EDWW/EDAY.toml
@@ -9,9 +9,5 @@ url = "https://chartfox.org/EDAY"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDAY"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/a507db90c294a8cb0951e9886d9852f8.html"
 
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/eday-briefing"

--- a/data/EDWW/EDAZ.toml
+++ b/data/EDWW/EDAZ.toml
@@ -9,9 +9,6 @@ url = "https://chartfox.org/EDAZ"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDAZ"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/bd2d83682ab6701ab13d507c74aab687.html"
 
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/edaz-briefing"
+

--- a/data/EDWW/EDDB.toml
+++ b/data/EDWW/EDDB.toml
@@ -9,7 +9,7 @@ url = "https://chartfox.org/EDDB"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDDB"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/c90d806c4bf14e0c697918999f567b0f.html"
 
 [[airport.links]]
 category = "Briefing"

--- a/data/EDWW/EDDH.toml
+++ b/data/EDWW/EDDH.toml
@@ -9,17 +9,12 @@ url = "https://chartfox.org/EDDH"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDDH"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/ae4726f1fa20f6a645af025f806bb1c7.html"
 
 [[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-bremen-fir-edww/chapter/eddh-hamburg-airport"
-
-[[airport.links]]
-category = "Briefing"
-name = "vACDM Pilot Guide"
-url = "https://knowledgebase.vatsim-germany.org/books/vacdm/page/vacdm-pilot-guide"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDDV.toml
+++ b/data/EDWW/EDDV.toml
@@ -9,17 +9,12 @@ url = "https://chartfox.org/EDDV"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDDV"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/25ca701b853f06a5d1bba393f5a3c32f.html"
 
 [[airport.links]]
 category = "Briefing"
 name = "Pilotbriefing"
 url = "https://knowledgebase.vatsim-germany.org/books/airports-bremen-fir-edww/chapter/eddv-hannover"
-
-[[airport.links]]
-category = "Briefing"
-name = "vACDM Pilot Guide"
-url = "https://knowledgebase.vatsim-germany.org/books/vacdm/page/vacdm-pilot-guide"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDDW.toml
+++ b/data/EDWW/EDDW.toml
@@ -9,7 +9,7 @@ url = "https://chartfox.org/EDDW"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDDW"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/39eb616813d03e0c6ffa56abb052bff3.html"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDHI.toml
+++ b/data/EDWW/EDHI.toml
@@ -9,7 +9,7 @@ url = "https://chartfox.org/EDHI"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDHI"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/d640a3a2626675952cf50b811bf494b7.html"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDHK.toml
+++ b/data/EDWW/EDHK.toml
@@ -9,7 +9,7 @@ url = "https://chartfox.org/EDHK"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDHK"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/9483613ec9a919c73f55a7485162fd0d.html"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDHL.toml
+++ b/data/EDWW/EDHL.toml
@@ -9,9 +9,4 @@ url = "https://chartfox.org/EDHL"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDHL"
-
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/edhl-briefing"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/272a2b2ef9e99898746e951012e47c16.html"

--- a/data/EDWW/EDOI.toml
+++ b/data/EDWW/EDOI.toml
@@ -4,4 +4,4 @@ icao = "EDOI"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDOI"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/5b9f42345e6ce5f696bc85bda0d53879.html"

--- a/data/EDWW/EDVE.toml
+++ b/data/EDWW/EDVE.toml
@@ -9,12 +9,7 @@ url = "https://chartfox.org/EDVE"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDVE"
-
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/edve-briefing"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/3766f3d82fbe6c28c64a47c00172bb83.html"
 
 [[airport.links]]
 category = "Briefing"

--- a/data/EDWW/EDVK.toml
+++ b/data/EDWW/EDVK.toml
@@ -9,12 +9,7 @@ url = "https://chartfox.org/EDVK"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDVK"
-
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/edvk-briefing"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/0cda638c31dc64f56aeaf0229b6c2dc2.html"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDWG.toml
+++ b/data/EDWW/EDWG.toml
@@ -4,7 +4,7 @@ icao = "EDWG"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDWG"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/67c4edf4474254d3226d9a0f6cef8137.html"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDWI.toml
+++ b/data/EDWW/EDWI.toml
@@ -9,7 +9,7 @@ url = "https://chartfox.org/EDWI"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDWI"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/445e3976039522725318e08d2d56639d.html"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/EDXW.toml
+++ b/data/EDWW/EDXW.toml
@@ -9,12 +9,7 @@ url = "https://chartfox.org/EDXW"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?EDXW"
-
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/edxw-briefing"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/6071b2391c4485947500c4c5ba688b6e.html"
 
 [[airport.links]]
 category = "Scenery"

--- a/data/EDWW/ETMN.toml
+++ b/data/EDWW/ETMN.toml
@@ -9,9 +9,6 @@ url = "https://chartfox.org/ETMN"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?ETMN"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/6b5e6159106c29aba461c213ab0b8ae6.html"
 
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/etmn-briefing"
+

--- a/data/EDWW/ETNL.toml
+++ b/data/EDWW/ETNL.toml
@@ -9,9 +9,6 @@ url = "https://chartfox.org/ETNL"
 [[airport.links]]
 category = "Charts"
 name = "Charts (VFR)"
-url = "https://www.vfraip.de/?ETNL"
+url = "https://aip.dfs.de/BasicVFR/2024AUG22/chapter/9c18cbbc46e4e6a53894c564257cf75a.html"
 
-[[airport.links]]
-category = "Briefing"
-name = "Pilotbriefing"
-url = "https://vats.im/etnl-briefing"
+


### PR DESCRIPTION
Removed wrong Briefings and changed VFR Charts to the Offical DFS Page. Also Removed vACDM guide for the hole FIR as is not used in the FIR Bremen.