### PR TITLE
Add GSX category to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Manages the airport data used on the VATSIM Germany homepage.
 icao = "EDDY"
 
 [[airport.links]]
-category = "Scenery" | "Charts" | "Briefing" | NONE
+category = "Scenery" | "Charts" | "Briefing" | "GSX Config" | NONE
 name = "Display Name 1"
 url = "https://example.url"
 ```
@@ -31,7 +31,3 @@ name = "Display Name 2"
 url = "https://example2.url"
 
 ```
-
-# TODO:
-
-- give warnings using PRs or Discord hook?

--- a/src/views/airport.py
+++ b/src/views/airport.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, HttpUrl
 
 
 class Link(BaseModel):
-    category: Literal["Scenery", "Charts", "Briefing"] | None = None
+    category: Literal["Scenery", "Charts", "Briefing", "GSX Config"] | None = None
     name: str
     url: HttpUrl
 

--- a/tests/views/test_airport.py
+++ b/tests/views/test_airport.py
@@ -22,6 +22,11 @@ class TestAirportDataModel(unittest.TestCase):
                             "name": "Pilotbriefing",
                             "url": "https://aip.dfs.de/BasicVFR/pages/C019C8.html",
                         },
+                        {
+                            "category": "GSX Config",
+                            "name": "GSX Config",
+                            "url": "https://some.url",
+                        },
                     ],
                 },
                 {"icao": "EDDL", "links": []},

--- a/tests/views/test_airport.py
+++ b/tests/views/test_airport.py
@@ -1,0 +1,76 @@
+import unittest
+
+from pydantic import ValidationError
+
+from views.airport import AirportData
+
+
+class TestAirportDataModel(unittest.TestCase):
+    def test_valid_airport_data(self):
+        data = {
+            "airports": [
+                {
+                    "icao": "EDDF",
+                    "links": [
+                        {
+                            "category": "Charts",
+                            "name": "Charts (IFR)",
+                            "url": "https://chartfox.org/EDDF",
+                        },
+                        {
+                            "category": "Briefing",
+                            "name": "Pilotbriefing",
+                            "url": "https://aip.dfs.de/BasicVFR/pages/C019C8.html",
+                        },
+                    ],
+                },
+                {"icao": "EDDL", "links": []},
+            ]
+        }
+
+        airport_data = AirportData(**data)
+        self.assertEqual(len(airport_data.airports), 2)
+        self.assertEqual(airport_data.airports[0].icao, "EDDF")
+        self.assertEqual(airport_data.airports[1].links, [])
+
+    def test_invalid_url(self):
+        data = {
+            "airports": [
+                {
+                    "icao": "EGLL",
+                    "links": [
+                        {
+                            "category": "Briefing",
+                            "name": "Heathrow Briefing",
+                            "url": "not-a-valid-url",
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with self.assertRaises(ValidationError):
+            AirportData(**data)
+
+    def test_invalid_category(self):
+        data = {
+            "airports": [
+                {
+                    "icao": "EDDF",
+                    "links": [
+                        {
+                            "category": "InvalidCategory",
+                            "name": "EDDF Charts",
+                            "url": "https://example.com/eddf/charts",
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with self.assertRaises(ValidationError):
+            AirportData(**data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/views/test_airport.py
+++ b/tests/views/test_airport.py
@@ -23,6 +23,11 @@ class TestAirportDataModel(unittest.TestCase):
                             "url": "https://aip.dfs.de/BasicVFR/pages/C019C8.html",
                         },
                         {
+                            "category": "Scenery",
+                            "name": "Scenery",
+                            "url": "https://some.url",
+                        },
+                        {
                             "category": "GSX Config",
                             "name": "GSX Config",
                             "url": "https://some.url",


### PR DESCRIPTION
- adds "GSX Config" as Category for links

closes #32 
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/VATGER-Nav/airport-data/tree/main) ([c30d877](https://github.com/VATGER-Nav/airport-data/commit/c30d877d90ec91df9a029d26c226020e66915e8f)) | [#35](https://github.com/VATGER-Nav/airport-data/pull/35) ([4ab5b66](https://github.com/VATGER-Nav/airport-data/commit/4ab5b66b0f39854cedbf260aa7927411eae3eb88)) |  +/-  |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                                10.1% |                                                                                                                                                             15.2% | +5.0% |
| **Test Execution Time** |                                                                                                                                                                   1s |                                                                                                                                                                1s |    0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (c30d877) | #35 (4ab5b66) |  +/-  |
  |---------------------|----------------|---------------|-------|
+ | Coverage            |          10.1% |         15.2% | +5.0% |
  |   Files             |             13 |            13 |     0 |
  |   Lines             |            217 |           217 |     0 |
+ |   Covered           |             22 |            33 |   +11 |
  | Test Execution Time |             1s |            1s |    0s |
```

</details>


### Code coverage of files in pull request scope (0.0% → 100.0%)

|                                                                   Files                                                                   | Coverage |   +/-   |  Status  |
|-------------------------------------------------------------------------------------------------------------------------------------------|---------:|--------:|---------:|
| [src/views/airport.py](https://github.com/VATGER-Nav/airport-data/blob/84849838c63dd8a192b117a60d8c6a92ca5fb6e0/src%2Fviews%2Fairport.py) | 100.0%   | +100.0% | modified |

---
Reported by octocov
<!-- octocov -->
